### PR TITLE
Fix catalog search result calculation

### DIFF
--- a/src/app/code/community/Dh/EmptyHandles/Model/Handler/Catalogsearch/Result/FilterFactory.php
+++ b/src/app/code/community/Dh/EmptyHandles/Model/Handler/Catalogsearch/Result/FilterFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * Factory class for instantiating filter models
+ *
+ * @category Dh
+ * @package Dh_EmptyHandles
+ * @author Geza Buza <gbuza@sessiondigital.com>
+ */
+class Dh_EmptyHandles_Model_Handler_Catalogsearch_Result_FilterFactory
+{
+    /** @var array $_filterModels Attribute to class map used for MySQL fulltext search */
+    protected $_filterModels = [
+        'category' => 'catalog/layer_filter_category',
+        'attribute' => 'catalog/layer_filter_attribute',
+        'price' => 'catalog/layer_filter_price',
+        'decimal' => 'catalog/layer_filter_decimal',
+    ];
+
+    /** @var array $_enterpriseFilterModels Attribute to class map used for Solr search */
+    protected $_enterpriseFilterModels = [
+        'category' => 'enterprise_search/catalog_layer_filter_category',
+        'attribute' => 'enterprise_search/catalog_layer_filter_attribute',
+        'price' => 'enterprise_search/catalog_layer_filter_price',
+        'decimal' => 'enterprise_search/catalog_layer_filter_decimal',
+    ];
+
+    /**
+     * Create a filter model for the given attribute
+     *
+     * @param Mage_Catalog_Model_Resource_Eav_Attribute $attribute
+     * @throws RuntimeException Thrown when No filter model is defined for the given attribute
+     *
+     * @return Mage_Catalog_Model_Layer_Filter_Abstract
+     */
+    public function create(Mage_Catalog_Model_Resource_Eav_Attribute $attribute)
+    {
+        $keys = [$attribute->getAttributeCode(), $attribute->getBackendType(), 'attribute'];
+        $classMap = $this->_getClassMap();
+
+        foreach ($keys as $key) {
+            if (isset($classMap[$key])) {
+                return Mage::getModel($classMap[$key]);
+            }
+        }
+
+        throw new RuntimeException(sprintf('Filter model is not defined for "%s" attribute', $attribute->getName()));
+    }
+
+    /**
+     * @return array
+     */
+    protected function _getClassMap()
+    {
+        $hasEnterpriseSearchModule = Mage::helper('core')->isModuleEnabled('Enterprise_Search');
+        return $hasEnterpriseSearchModule && Mage::helper('enterprise_search')->getIsEngineAvailableForNavigation()
+            ? $this->_enterpriseFilterModels
+            : $this->_filterModels;
+    }
+}

--- a/src/app/code/community/Dh/EmptyHandles/Model/Handler/Catalogsearch/Result/Index.php
+++ b/src/app/code/community/Dh/EmptyHandles/Model/Handler/Catalogsearch/Result/Index.php
@@ -19,10 +19,34 @@ class Dh_EmptyHandles_Model_Handler_Catalogsearch_Result_Index
      */
 	public function execute(Varien_Event $event)
 	{
-		$numResults = (bool)Mage::helper('catalogsearch')->getQuery()->getNumResults();
+		$numResults = $this->_getLayer()->getProductCollection()->getSize();
 		if (! $numResults) {
 			$this->_addHandle('catalogsearch_result_index_empty');
 		}
 		return $this;
 	}
+
+    /**
+     * Load the layer model with navigation layer filters applied on it
+     *
+     * @return Mage_Catalog_Model_Layer
+     */
+    protected function _getLayer()
+    {
+        $layer = Mage::registry('current_layer');
+        $factory = $this->_getFilterModelFactory();
+        foreach ($layer->getFilterableAttributes() as $attribute) {
+            $filterModel = $factory->create($attribute);
+            $filterModel
+                ->setLayer($layer)
+                ->setAttributeModel($attribute)
+                ->apply(Mage::app()->getRequest(), null);
+        }
+        return $layer;
+    }
+
+    protected function _getFilterModelFactory()
+    {
+        return Mage::getModel('emptyhandles/handler_catalogsearch_result_filterFactory');
+    }
 }


### PR DESCRIPTION
The way how the module calculates the number of results is incorrect. When a layered navigation filter is active and the result is zero, then the module still thinks it has non-zero results, because only the search keyword is taken into account. This commit builds the navigation layer model properly by applying all active filters and finally counts the number of items in the result collection.
